### PR TITLE
Fix the top Firefox logo aspect on mobile

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -212,11 +212,8 @@ footer ul a{
   top: -60px;
 }
 .image-responsive{
-  min-width:320px;
-  max-width:320px;
+  max-width:400px;
   margin:auto;
-  min-height:240px;
-  height:100%;
   display:block;
 
 }


### PR DESCRIPTION
The width of the logo is wrong on the small screen.
