### PR TITLE
Tabzilla border

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -34,10 +34,10 @@
 }
 body {
   color: #FFFFFF;
-
   overflow-x: hidden;
   width: 100%;
   margin: 0;
+  border-top: 2px solid #fff;
 }
 a{
   color:#fff;
@@ -83,7 +83,7 @@ select, option {
 }
 #top-static-fix{
   margin-bottom: 50px;
-  padding: 96px 0 115px 0;
+  padding: 96px 0 67px 0;
   position:relative;
   z-index: 100;
   background: #0A86BC url(../images/full-bg-overlay-wo-globe.png) no-repeat scroll center top;


### PR DESCRIPTION
According to Mozilla style guide :
 add a 2 pixel white border to the top of the page (border-top: 2px solid #fff;)

https://www.mozilla.org/en-US/styleguide/websites/sandstone/tabzilla/
