### PR TITLE
The full stop moved into <a> tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
           <p class="text-center white"><span data-l10n-id="online-2">Help spread Firefox Online!</span></p>
         </div>
         <div class="small-12 msg-sub columns">
-          <p class="text-center"><span data-l10n-id="ways">Let's make sure Firefox is known to the millions of internet users around the world! Here are ways you can get social, spread your love for Firefox and get people to #ChooseIndependent on #fx10.</span></p>
+          <p class="text-center"><span data-l10n-id="ways">Let's make sure Firefox is known to the millions of internet users around the world! Here are ways you can get social, spread your love for Firefox and get people to</span> #ChooseIndependent <span data-l10n-id="ways-2">on</span> #fx10.</p>
         </div>
       </div>
       <div class="row col-tile">
@@ -229,7 +229,7 @@
           <img src="images/footer-mozilla-white.png"/>
         </div>
         <div class="small-12 large-4 columns">
-          <p><span data-l10n-id="copyright">Portions of this content are &#0169; 1998-2014 by individual mozilla.org contributors. Content available under a</span> <a href="https://www.mozilla.org/en-US/foundation/licensing/website-content" target="_blank" data-l10n-id="creative-commons-license">Creative Commons license</a>.</p>
+          <p><span data-l10n-id="copyright">Portions of this content are &#0169; 1998-2014 by individual mozilla.org contributors. Content available under a</span> <a href="https://www.mozilla.org/en-US/foundation/licensing/website-content" target="_blank" data-l10n-id="creative-commons-license">Creative Commons license.</a></p>
           <p><a href="https://www.mozilla.org/en-US/contribute/page" target="_blank" data-l10n-id="contribute">Contribute to this page</a></p>
         </div>
         <div class="small-12 large-6 columns">


### PR DESCRIPTION
It makes no sense when it's time to localization. Cause on all language there is no "full stop" And should be included into pontoon as well. Have moved the "full stop" from out of the <a> tag to into it.
